### PR TITLE
refactor: Refactor PLL code to increase readability and maintenance easeness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,10 @@ jobs:
     - name: Move firmware
       run: | 
         mkdir upload
-        mv .pio/build/mod1/firmware.uf2 upload/mod1.uf2
-        mv .pio/build/mod2/firmware.uf2 upload/mod2.uf2
-        mv .pio/build/mod3/firmware.uf2 upload/mod3.uf2
+        mv .pio/build/mk1_mod1/firmware.uf2 upload/mk1_mod1.uf2
+        mv .pio/build/mk2_mod1/firmware.uf2 upload/mk2_mod1.uf2
+        mv .pio/build/mk1_mod2/firmware.uf2 upload/mk1_mod2.uf2
+        mv .pio/build/mk2_mod2/firmware.uf2 upload/mk2_mod2.uf2
     
     - uses: actions/upload-artifact@v4
       if: github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,30 @@
 #Modules
-MODULE1 = mod1
-MODULE2 = mod2
-MODULE3 = mod3
+MODULE1 = mk1_mod1
+MODULE2 = mk1_mod2
+MODULE3 = mk2_mod1
+MODULE4 = mk2_mod2
 
-target: mod1 mod2 mod3
+target: mk1_mod1 mk1_mod2 mk2_mod1 mk2_mod2
 
 #Build only
-mod1: 
+mk1_mod1: 
 	pio run -e $(MODULE1) 
-mod2:
+mk1_mod2:
 	pio run -e $(MODULE2) 
-mod3:
+mk2_mod1:
 	pio run -e $(MODULE3)
+mk2_mod2:
+	pio run -e $(MODULE4)
 
 #Build and upload
-upload_mod1:
+upload_mk1_mod1:
 	pio run -e $(MODULE1) -t upload
-upload_mod2:
+upload_mk1_mod2:
 	pio run -e $(MODULE2) -t upload
-upload_mod3:
+upload_mk2_mod1:
 	pio run -e $(MODULE3) -t upload
+upload_mk2_mod2:
+	pio run -e $(MODULE4) -t upload
 
 #Remove build files
 clean:

--- a/include/communication.h
+++ b/include/communication.h
@@ -16,7 +16,4 @@
 #define DATA_EE_HEAD_PITCH_FEEDBACK     0x44
 #define DATA_EE_HEAD_ROLL_FEEDBACK      0x46
 
-// TODO: update to ROS2 equivalent
-#define DATA_PITCH                      0x04 // Deprecated?
-
 #endif

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -7,6 +7,9 @@
 #define DT_TEL 10     // 1000ms / 10   = 100 Hz
 #define DT_ENC 20     // 1000ms / 20   = 50 Hz
 
+// Timeouts
+#define CAN_TIMEOUT 1000
+
 // PWM configuration
 #define PWM_MAX_VALUE 1023
 #define PWM_FREQUENCY 15000

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -15,7 +15,7 @@
 #define I2C_SENS_SDA   18
 #define I2C_SENS_SCL   19
 
-#define ABSOLUTE_ENCODER_ADDRESS 0x40 // ToDo check, maybe 0x44
+#define ABSOLUTE_ENCODER_ADDRESS 0x40
 
 // Battery configuration
 #define BAT_LOW 11.1f

--- a/include/mod_config.h
+++ b/include/mod_config.h
@@ -1,29 +1,26 @@
 #ifndef module_configuration_h
 #define module_configuration_h
 
-// MOD_HEAD, MOD_MIDDLE, MOD_TAIL are defined in the makefile
+// MK1_MOD1, MK1_MOD2, MK2_MOD1, MK2_MOD2 are defined at build time
 
-#if defined(MOD_HEAD)
-#define CAN_ID    0x11  // HEAD
+#if defined(MK1_MOD1)
+#define CAN_ID    0x11  // MK1 first module (HEAD)
 #define MODC_EE
 #define SERVO_EE_PITCH_ID 6
 #define SERVO_EE_HEAD_ROLL_ID 4
 #define SERVO_EE_HEAD_PITCH_ID 2
 #define SERVO_SPEED 200
 
-#elif defined(MOD_MIDDLE)
-#define CAN_ID    0x12  // MIDDLE
+#elif defined(MK1_MOD2)
+#define CAN_ID    0x12  // MK1 second module (MIDDLE)
 #define MODC_YAW
 
-#elif defined(MOD_TAIL)
-#define CAN_ID    0x13  // TAIL
+#elif defined(MK2_MOD1)
+#define CAN_ID    0x21  // MK2 first module (HEAD)
+
+#elif defined(MK2_MOD1)
+#define CAN_ID    0x22  // MK2 second module (MIDDLE)
 #define MODC_YAW
-#define MODC_PITCH
-#define SERVO_A_ID 5
-#define SERVO_B_ID 1
-#define SERVO_MIN 200
-#define SERVO_MAX 800
-#define SERVO_SPEED 200
 #endif
 
 #endif

--- a/include/mod_config.h
+++ b/include/mod_config.h
@@ -18,7 +18,7 @@
 #elif defined(MK2_MOD1)
 #define CAN_ID    0x21  // MK2 first module (HEAD)
 
-#elif defined(MK2_MOD1)
+#elif defined(MK2_MOD2)
 #define CAN_ID    0x22  // MK2 second module (MIDDLE)
 #define MODC_YAW
 #endif

--- a/lib/Can/src/CanWrapper.cpp
+++ b/lib/Can/src/CanWrapper.cpp
@@ -1,0 +1,40 @@
+#include "CanWrapper.h"
+
+void CanWrapper::begin() {
+    mcp2515.reset();
+    mcp2515.setBitrate(CAN_125KBPS, MCP_8MHZ);
+
+    mcp2515.setConfigMode();// tell the MCP2515 next instructions are for configuration
+
+    // enable filtering for 29 bit address on both RX buffers
+    mcp2515.setFilterMask(MCP2515::MASK0, true, 0xFF00);
+    mcp2515.setFilterMask(MCP2515::MASK1, true, 0xFF00);
+
+    // set all filters to module's ID, so only packets for us get through
+    mcp2515.setFilter(MCP2515::RXF0, true, CAN_ID << 8);
+    mcp2515.setFilter(MCP2515::RXF1, true, CAN_ID << 8);
+    mcp2515.setFilter(MCP2515::RXF2, true, CAN_ID << 8);
+    mcp2515.setFilter(MCP2515::RXF3, true, CAN_ID << 8);
+    mcp2515.setFilter(MCP2515::RXF4, true, CAN_ID << 8);
+    mcp2515.setFilter(MCP2515::RXF5, true, CAN_ID << 8);
+
+    mcp2515.setNormalMode();
+}
+
+bool CanWrapper::sendMessage(uint8_t id, const void* data, uint8_t length) {
+    struct can_frame msg = {0};
+    msg.can_id = CAN_ID | CAN_EFF_FLAG | (id << 16);
+    msg.can_dlc = length;
+    memcpy(msg.data, data, length);
+    return mcp2515.sendMessage(&msg) == MCP2515::ERROR_OK;
+}
+
+bool CanWrapper::readMessage(uint8_t* id, byte* data) {
+    struct can_frame msg = {0};
+    if (mcp2515.readMessage(&msg) == MCP2515::ERROR_OK) {
+        *id = msg.can_id;
+        memcpy(data, msg.data, msg.can_dlc);
+        return true;
+    }
+    return false;
+}

--- a/lib/Can/src/CanWrapper.h
+++ b/lib/Can/src/CanWrapper.h
@@ -1,0 +1,47 @@
+#ifndef CAN_WRAPPER_H
+#define CAN_WRAPPER_H
+
+#include "mcp2515.h"
+#include "mod_config.h"
+
+/**
+ * @class CanWrapper
+ * @brief A wrapper class for the MCP2515 CAN controller.
+ */
+class CanWrapper {
+public:
+    /**
+     * @brief Constructor that initializes the MCP2515 object with the provided parameters.
+     * @param csPin Chip select pin for the MCP2515.
+     * @param speed SPI speed for the MCP2515.
+     * @param spi SPI interface to use.
+     */
+    CanWrapper(uint8_t csPin, uint32_t speed, SPIClass* spi) : mcp2515(csPin, speed, spi) {} 
+
+    /**
+     * @brief Initializes the CAN module.
+     */
+    void begin();
+
+    /**
+     * @brief Sends a CAN message.
+     * @param id The ID of the CAN message.
+     * @param data Pointer to the data to be sent.
+     * @param length Length of the data to be sent.
+     * @return True if the message was sent successfully, false otherwise.
+     */
+    bool sendMessage(uint8_t id, const void* data, uint8_t length);
+
+    /**
+     * @brief Reads a CAN message.
+     * @param id Pointer to store the ID of the received CAN message.
+     * @param data Pointer to store the data of the received CAN message.
+     * @return True if a message was read successfully, false otherwise.
+     */
+    bool readMessage(uint8_t* id, byte* data);
+
+private:
+    MCP2515 mcp2515; ///< MCP2515 object for CAN communication.
+};
+
+#endif // CAN_WRAPPER_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs = mod1
+default_envs = mk1_mod1
 
 [env]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -11,17 +11,22 @@ board_build.filesystem_size = 1m
 lib_deps = 
     adafruit/Adafruit SH110X@^2.1.11
 
-[env:mod1]
+[env:mk1_mod1]
 build_flags =
     -I "./include"
-    -D MOD_HEAD
+    -D MK1_MOD1
 
-[env:mod2]
+[env:mk1_mod2]
 build_flags =
     -I "./include"
-    -D MOD_MIDDLE
+    -D MK1_MOD2
 
-[env:mod3]
+[env:mk2_mod1]
 build_flags =
     -I "./include"
-    -D MOD_TAIL
+    -D MK2_MOD1
+
+[env:mk2_mod2]
+build_flags =
+    -I "./include"
+    -D MK2_MOD2

--- a/src/PicoLowLevel.cpp
+++ b/src/PicoLowLevel.cpp
@@ -136,7 +136,7 @@ void loop() {
     // Received CAN message with setpoint
     time_data = time_cur;
     handleSetpoint(msg_id, msg_data);
-  } else if (time_cur - time_data > 1000 && time_data != -1) { 
+  } else if (time_cur - time_data > CAN_TIMEOUT && time_data != -1) { 
     //if we do not receive data for more than a second stop motors
     time_data = -1;
     Debug.println("Stopping motors after timeout.", Levels::INFO);

--- a/src/PicoLowLevel.cpp
+++ b/src/PicoLowLevel.cpp
@@ -8,18 +8,22 @@
 #include "definitions.h"
 #include "mod_config.h"
 #include "Debug.h"
-#include "mcp2515.h"
 #include "communication.h"
 #include "WebManagement.h"
 #include "Display.h"
+#include "CanWrapper.h"
+
+void okInterrupt();
+void navInterrupt();
+void sendFeedback();
+void handleSetpoint(uint8_t msg_id, const byte* msg_data);
 
 int time_bat = 0;
 int time_tel = 0;
 int time_data = 0;
 int time_tel_avg = DT_TEL;
 
-struct can_frame canMsg;
-MCP2515 mcp2515(5, 10000000UL, &SPI); // passing all parameters avoids premature initialization of SPI, which should be done in setup()
+CanWrapper canW(5, 10000000UL, &SPI);
 
 SmartMotor motorTrLeft(DRV_TR_LEFT_PWM, DRV_TR_LEFT_DIR, ENC_TR_LEFT_A, ENC_TR_LEFT_B, false);
 SmartMotor motorTrRight(DRV_TR_RIGHT_PWM, DRV_TR_RIGHT_DIR, ENC_TR_RIGHT_A, ENC_TR_RIGHT_B, true);
@@ -40,81 +44,6 @@ WebManagement wm(CONF_PATH);
 
 Display display;
 
-void okInterrupt() {
-  display.okInterrupt();
-}
-
-void navInterrupt() {
-  display.navInterrupt();
-}
-
-void sendFeedback() {
-  canMsg = {0};
-  canMsg.can_id = CAN_ID | CAN_EFF_FLAG; // source
-
-  // send motor feedback as float
-  float speedR = motorTrRight.getSpeed();
-  float speedL = motorTrLeft.getSpeed();
-
-  canMsg.can_dlc = 8;
-  canMsg.can_id |= MOTOR_FEEDBACK << 16;
-  canMsg.data[0] = ((uint8_t*)&speedL)[0];
-  canMsg.data[1] = ((uint8_t*)&speedL)[1];
-  canMsg.data[2] = ((uint8_t*)&speedL)[2];
-  canMsg.data[3] = ((uint8_t*)&speedL)[3];
-  canMsg.data[4] = ((uint8_t*)&speedR)[0];
-  canMsg.data[5] = ((uint8_t*)&speedR)[1];
-  canMsg.data[6] = ((uint8_t*)&speedR)[2];
-  canMsg.data[7] = ((uint8_t*)&speedR)[3];
-  mcp2515.sendMessage(&canMsg);
-
-  // send yaw angle of the joint if this module has one
-#ifdef MODC_YAW
-  encoderYaw.update();
-  float angle = encoderYaw.readAngle();
-
-  canMsg = {0};
-  canMsg.can_id = CAN_ID | CAN_EFF_FLAG;
-  canMsg.can_dlc = 4;
-  canMsg.can_id |= JOINT_YAW_FEEDBACK << 16;
-  canMsg.data[0] = ((uint8_t*)&angle)[0];
-  canMsg.data[1] = ((uint8_t*)&angle)[1];
-  canMsg.data[2] = ((uint8_t*)&angle)[2];
-  canMsg.data[3] = ((uint8_t*)&angle)[3];
-  mcp2515.sendMessage(&canMsg);
-#endif
-
-  // send end effector data (if module has it)
-#ifdef MODC_EE
-  int pitch = motorEEPitch.readPosition();
-  int headPitch = motorEEHeadPitch.readPosition();
-  int headRoll = motorEEHeadRoll.readPosition();
-
-  canMsg = {0};
-  canMsg.can_id = CAN_ID | CAN_EFF_FLAG;
-  canMsg.can_dlc = 4;
-  canMsg.can_id |= DATA_EE_PITCH_FEEDBACK << 16;
-  memcpy(canMsg.data, &pitch, 4);
-  mcp2515.sendMessage(&canMsg);
-
-  canMsg = {0};
-  canMsg.can_id = CAN_ID | CAN_EFF_FLAG;
-  canMsg.can_dlc = 4;
-  canMsg.can_id |= DATA_EE_HEAD_PITCH_FEEDBACK << 16;
-  memcpy(canMsg.data, &headPitch, 4);
-  mcp2515.sendMessage(&canMsg);
-
-  canMsg = {0};
-  canMsg.can_id = CAN_ID | CAN_EFF_FLAG;
-  canMsg.can_dlc = 4;
-  canMsg.can_id |= DATA_EE_HEAD_ROLL_FEEDBACK << 16;
-  memcpy(canMsg.data, &headRoll, 4);
-  mcp2515.sendMessage(&canMsg);
-#endif
-
-  canMsg = {0};
-}
-
 void setup() {
   Serial.begin(115200);
   Debug.setLevel(Levels::INFO); // comment to set debug verbosity to debug
@@ -134,21 +63,7 @@ void setup() {
   wm.begin(WIFI_SSID, WIFI_PWD, hostname.c_str());
 
   // CAN initialization
-  mcp2515.reset();
-  mcp2515.setBitrate(CAN_125KBPS, MCP_8MHZ);
-
-  mcp2515.setConfigMode(); // tell the MCP2515 next instructions are for configuration
-  // enable filtering for 29 bit address on both RX buffers
-  mcp2515.setFilterMask(MCP2515::MASK0, true, 0xFF00);
-  mcp2515.setFilterMask(MCP2515::MASK1, true, 0xFF00);
-  // set all filters to module's ID, so only packets for us get through
-  mcp2515.setFilter(MCP2515::RXF0, true, CAN_ID<<8);
-  mcp2515.setFilter(MCP2515::RXF1, true, CAN_ID<<8);
-  mcp2515.setFilter(MCP2515::RXF2, true, CAN_ID<<8);
-  mcp2515.setFilter(MCP2515::RXF3, true, CAN_ID<<8);
-  mcp2515.setFilter(MCP2515::RXF4, true, CAN_ID<<8);
-  mcp2515.setFilter(MCP2515::RXF5, true, CAN_ID<<8);
-  mcp2515.setNormalMode();
+  canW.begin();
 
   // initializing PWM
   analogWriteFreq(PWM_FREQUENCY); // switching frequency to 15kHz
@@ -175,7 +90,7 @@ void setup() {
 
 #ifdef MODC_YAW    
   encoderYaw.update();
-  oldAngle = encoderYaw.readAngle();
+  encoderYaw.readAngle();
   encoderYaw.setZero();
 #endif
 
@@ -192,6 +107,8 @@ void setup() {
 
 void loop() {
   int time_cur = millis();
+  uint8_t msg_id;
+  byte msg_data[8];
 
   // update motors
   motorTrLeft.update();
@@ -214,58 +131,13 @@ void loop() {
     sendFeedback();
   }
 
-  if (mcp2515.readMessage(&canMsg) == MCP2515::ERROR_OK) {
+  if (canW.readMessage(&msg_id, msg_data)) {
+
+    // Received CAN message with setpoint
     time_data = time_cur;
-
-    Debug.println("RECEIVED CANBUS DATA");
-    int16_t data;
-    byte buf[4];
-
-    byte type = canMsg.can_id >> 16;
-
-    switch (type) {
-      case MOTOR_SETPOINT:
-        // take the first four bytes from the array and and put them in a float
-        float leftSpeed, rightSpeed;
-        memcpy(&leftSpeed, canMsg.data, 4);
-        memcpy(&rightSpeed, canMsg.data+4, 4);
-        motorTrLeft.setSpeed(leftSpeed);
-        motorTrRight.setSpeed(rightSpeed);
-
-        Debug.print("TRACTION DATA :\tleft: \t");
-        Debug.print(leftSpeed);
-        Debug.print("\tright: \t");
-        Debug.println(rightSpeed);
-        break;
-      case DATA_EE_PITCH_SETPOINT:
-        memcpy(&data, canMsg.data, 2);
-#ifdef MODC_EE
-        motorEEPitch.moveSpeed(data, SERVO_SPEED);
-#endif
-        Debug.print("PITCH END EFFECTOR MOTOR DATA : \t");
-        Debug.println(data);
-        break;
-
-      case DATA_EE_HEAD_PITCH_SETPOINT:
-        memcpy(&data, canMsg.data, 2);
-#ifdef MODC_EE
-        motorEEHeadPitch.moveSpeed(data, SERVO_SPEED);
-#endif
-        Debug.print("HEAD PITCH END EFFECTOR MOTOR DATA : \t");
-        Debug.println(data);
-        break;
-
-      case DATA_EE_HEAD_ROLL_SETPOINT:
-        memcpy(&data, canMsg.data, 2);
-#ifdef MODC_EE
-        motorEEHeadRoll.moveSpeed(data, SERVO_SPEED);
-#endif
-        Debug.print("HEAD ROLL END EFFECTOR MOTOR DATA : \t");
-        Debug.println(data);
-        break;
-    }
-    
-  } else if (time_cur - time_data > 1000 && time_data != -1) { //if we do not receive data for more than a second stop motors
+    handleSetpoint(msg_id, msg_data);
+  } else if (time_cur - time_data > 1000 && time_data != -1) { 
+    //if we do not receive data for more than a second stop motors
     time_data = -1;
     Debug.println("Stopping motors after timeout.", Levels::INFO);
     motorTrLeft.stop();
@@ -274,4 +146,94 @@ void loop() {
 
   wm.handle();
   display.handleGUI();
+}
+
+/**
+ * @brief Handles the setpoint messages received via CAN bus.
+ * @param msg_id ID of the received message.
+ * @param msg_data Pointer to the message data.
+ */
+void handleSetpoint(uint8_t msg_id, const byte* msg_data) {
+  int16_t servo_data;
+  Debug.println("RECEIVED CANBUS DATA");
+
+  switch (msg_id) {
+    case MOTOR_SETPOINT:
+      float leftSpeed, rightSpeed;
+      memcpy(&leftSpeed, msg_data, 4);
+      memcpy(&rightSpeed, msg_data + 4, 4);
+      motorTrLeft.setSpeed(leftSpeed);
+      motorTrRight.setSpeed(rightSpeed);
+
+      Debug.println("TRACTION DATA :\tleft: \t" + String(leftSpeed) + "\tright: \t" + String(rightSpeed));
+      break;
+
+    case DATA_EE_PITCH_SETPOINT:
+      memcpy(&servo_data, msg_data, 2);
+#ifdef MODC_EE
+      motorEEPitch.moveSpeed(servo_data, SERVO_SPEED);
+#endif
+      Debug.print("PITCH END EFFECTOR MOTOR DATA : \t");
+      Debug.println(servo_data);
+      break;
+
+    case DATA_EE_HEAD_PITCH_SETPOINT:
+      memcpy(&servo_data, msg_data, 2);
+#ifdef MODC_EE
+      motorEEHeadPitch.moveSpeed(servo_data, SERVO_SPEED);
+#endif
+      Debug.print("HEAD PITCH END EFFECTOR MOTOR DATA : \t");
+      Debug.println(servo_data);
+      break;
+
+    case DATA_EE_HEAD_ROLL_SETPOINT:
+      memcpy(&servo_data, msg_data, 2);
+#ifdef MODC_EE
+      motorEEHeadRoll.moveSpeed(servo_data, SERVO_SPEED);
+#endif
+      Debug.print("HEAD ROLL END EFFECTOR MOTOR DATA : \t");
+      Debug.println(servo_data);
+      break;
+  }
+}
+
+/**
+ * @brief Sends feedback data over CAN bus.
+ *
+ * This function sends various feedback data including motor speeds, yaw angle, and end effector positions
+ * if the respective modules are enabled.
+ *
+ * @note The function uses conditional compilation to include/exclude parts of the code based on the presence of specific modules.
+ */
+void sendFeedback() {
+
+  // send motor data
+  float speeds[2] = {motorTrLeft.getSpeed(), motorTrRight.getSpeed()};
+  canW.sendMessage(MOTOR_FEEDBACK, speeds, 8);
+
+  // send yaw angle of the joint if this module has one
+#ifdef MODC_YAW
+  encoderYaw.update();
+  float angle = encoderYaw.readAngle();
+  canW.sendMessage(JOINT_YAW_FEEDBACK, &angle, 4);
+#endif
+
+  // send end effector data (if module has it)
+#ifdef MODC_EE
+  int pitch = motorEEPitch.readPosition();
+  int headPitch = motorEEHeadPitch.readPosition();
+  int headRoll = motorEEHeadRoll.readPosition();
+
+  canW.sendMessage(DATA_EE_PITCH_FEEDBACK, &pitch, 4);
+  canW.sendMessage(DATA_EE_HEAD_PITCH_FEEDBACK, &headPitch, 4);
+  canW.sendMessage(DATA_EE_HEAD_ROLL_FEEDBACK, &headRoll, 4);
+#endif
+}
+
+void okInterrupt() {
+  display.okInterrupt();
+}
+
+void navInterrupt() {
+  display.navInterrupt();
 }

--- a/src/PicoLowLevel.cpp
+++ b/src/PicoLowLevel.cpp
@@ -36,13 +36,6 @@ DynamixelMotor motorEEHeadPitch(SERVO_EE_HEAD_PITCH_ID);
 DynamixelMotor motorEEHeadRoll(SERVO_EE_HEAD_ROLL_ID);
 #endif
 
-#ifdef MODC_PITCH
-DynamixelMotor motorPitchA(SERVO_A_ID);
-DynamixelMotor motorPitchB(SERVO_B_ID);
-#endif
-
-float oldAngle;
-
 WebManagement wm(CONF_PATH);
 
 Display display;
@@ -171,7 +164,7 @@ void setup() {
   motorTrLeft.calibrate();
   motorTrRight.calibrate();
 
-#if defined MODC_PITCH || defined MODC_EE
+#if defined MODC_EE
   Serial1.setRX(1);
   Serial1.setTX(0);
   Dynamixel.setSerial(&Serial1);
@@ -244,17 +237,6 @@ void loop() {
         Debug.print("\tright: \t");
         Debug.println(rightSpeed);
         break;
-      case DATA_PITCH:
-        data = canMsg.data[1] | canMsg.data[2]<<8;
-#ifdef MODC_PITCH
-        data = map(data, 0, 1023, SERVO_MIN, SERVO_MAX);
-        motorPitchA.moveSpeed(data, SERVO_SPEED);
-        motorPitchB.moveSpeed(motorPitchB.readPosition() + motorPitchA.readPosition() - data, SERVO_SPEED);
-#endif
-        Debug.print("PITCH MOTOR DATA : \t");
-        Debug.println(data);
-        break;
-
       case DATA_EE_PITCH_SETPOINT:
         memcpy(&data, canMsg.data, 2);
 #ifdef MODC_EE


### PR DESCRIPTION
To increase readability, maintenance easeness and resilience to errors the CAN message handling procedure for inbound and outbound communications has been moved to functions outside of the main `loop`.

Moreover a `CanWrapper` class has been created to handle CAN related operation to reduce code duplication and some causes of error.

Finally the module configuration has been updated to include MK2 support and deprecate tail lifting capabilities

Next step will consist in infinite loops removal and necessary modifications to the track motors setup procedure