### PR TITLE
fix(arm): prevent violent startup motion and fix error checking

### DIFF
--- a/PicoLowLevel/PicoLowLevel.ino
+++ b/PicoLowLevel/PicoLowLevel.ino
@@ -869,12 +869,19 @@ void MODC_ARM_INIT()
   // is enabled, then smoothly move to home position via profile velocity.
   int32_t current_pos_1LR[2];
   int32_t current_pos_2, current_pos_3, current_pos_4, current_pos_5, current_pos_6;
-  ARM_dxl.getPresentPosition(current_pos_1LR);
-  ARM_mot_2.getPresentPosition(current_pos_2);
-  ARM_mot_3.getPresentPosition(current_pos_3);
-  ARM_mot_4.getPresentPosition(current_pos_4);
-  ARM_mot_5.getPresentPosition(current_pos_5);
-  ARM_mot_6.getPresentPosition(current_pos_6);
+
+  bool posReadOk =
+    ARM_dxl.getPresentPosition(current_pos_1LR) == 0 &&
+    ARM_mot_2.getPresentPosition(current_pos_2) == 0 &&
+    ARM_mot_3.getPresentPosition(current_pos_3) == 0 &&
+    ARM_mot_4.getPresentPosition(current_pos_4) == 0 &&
+    ARM_mot_5.getPresentPosition(current_pos_5) == 0 &&
+    ARM_mot_6.getPresentPosition(current_pos_6) == 0;
+
+  if (!posReadOk) {
+    Debug.println("ARM init: position reads failed, torque disabled", Levels::WARN);
+    return;
+  }
 
   // Pre-load goal position registers with current positions (while torque is off)
   ARM_dxl.setGoalPosition_EPCM(current_pos_1LR);


### PR DESCRIPTION
## Summary

Fixes violent arm startup motion and several related bugs. **Hardware-tested**: torque enables smoothly, arm moves to home position without jerking.

## Changes

1. **Torque-before-position fix** (primary cause): Read current motor positions and pre-load goal registers *before* enabling torque, so motors stay in place when torque turns on, then smoothly move to home position via profile velocity/acceleration
2. **`error_var = 4` → `== 4`**: Assignment instead of comparison broke round-robin error checking — only motor 6 was ever scanned
3. **Missing `break` in `JOINT_ROLL_2_SETPOINT`**: Fall-through to `MOTOR_TRACTION_REBOOT` caused every joint roll command to reboot traction motors
4. **Removed dead `first_startup_arm`**: Was always `false`, superseded by the new always-read-before-torque approach

## Testing

- [x] Compiled all 3 module variants (MK2_MOD1/2/3)
- [x] Uploaded to Pico, verified smooth arm startup (no violent motion)
- [x] Verify joint roll commands don't reboot traction (MOD2/MOD3)
- [x] Verify error status cycles through all 7 arm motors

Closes #24