### PR TITLE
feat: Current limit protection for XM540 motors

### DIFF
--- a/PicoLowLevel/PicoLowLevel.ino
+++ b/PicoLowLevel/PicoLowLevel.ino
@@ -965,6 +965,12 @@ void MODC_ARM_INIT()
   ARM_mot_5.setOperatingMode(4);
   ARM_mot_6.setOperatingMode(4);
 
+  // Current limit for XM540 motors only (IDs 210, 211, 112)
+  // XL430 motors (113, 214, 215, 216) do not have this register
+  mot_Left_1_ARM.setCurrentLimit(ARM_XM540_CURRENT_LIMIT);
+  mot_Right_1_ARM.setCurrentLimit(ARM_XM540_CURRENT_LIMIT);
+  ARM_mot_2.setCurrentLimit(ARM_XM540_CURRENT_LIMIT);
+
   delay(10);
   // Set Profile Velocity and Profile Acceleration for smooth motion.
   mot_Left_1_ARM.setProfileVelocity(ProfileVelocity);

--- a/PicoLowLevel/include/definitions.h
+++ b/PicoLowLevel/include/definitions.h
@@ -27,6 +27,9 @@
 #define I2C_ADC_SCL   3
 
 #define ABSOLUTE_ENCODER_ADDRESS 0x40
+
+// Dynamixel XM540 current limit (EEPROM addr 38, 2.69mA/unit, max 2047)
+#define ARM_XM540_CURRENT_LIMIT 1200  // ~3.2A
 //
 // Timeouts
 #define CAN_TIMEOUT 1000

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.cpp
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.cpp
@@ -179,6 +179,18 @@ uint8_t DynamixelLL::checkArraySize(uint8_t arraySize) const
 // ===============================
 
 
+uint8_t DynamixelLL::setCurrentLimit(uint16_t limit)
+{
+    if (limit > 2047) limit = 2047;
+    return writeRegister(38, limit, 2);
+}
+
+uint8_t DynamixelLL::getCurrentLimit(uint16_t &limit)
+{
+    return readRegister(38, limit, 2);
+}
+
+
 uint8_t DynamixelLL::writeRegister(uint16_t address, uint32_t value, uint8_t size)
 {
     if (_sync)

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.h
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.h
@@ -161,8 +161,38 @@ public:
     template <uint8_t N>
     uint8_t setHomingOffset_A(const float (&offsetAngle)[N]);
 
+    /**     * @brief Sets the current limit for XM-series motors (EEPROM address 38).
+     * @param limit Current limit in servo units (2.69mA per unit, max 2047 ≈ 5.5A).
+     * @return uint8_t 0 on success, nonzero on error.
+     */
+    uint8_t setCurrentLimit(uint16_t limit);
+
     /**
-     * @brief Sets the actuator’s desired output position (pulses) for Position Control Mode.
+     * @brief Sets the current limit for multiple XM-series motors.
+     * @tparam N Size of the input array, must match the number of motors in sync.
+     * @param limits Array of current limits for each motor.
+     * @return uint8_t 0 on success, nonzero on error.
+     */
+    template <uint8_t N>
+    uint8_t setCurrentLimit(const uint16_t (&limits)[N]);
+
+    /**
+     * @brief Reads the current limit setting.
+     * @param limit Reference to store the current limit value.
+     * @return uint8_t 0 on success, nonzero on error.
+     */
+    uint8_t getCurrentLimit(uint16_t &limit);
+
+    /**
+     * @brief Reads the current limit for multiple motors.
+     * @tparam N Size of the input array, must match the number of motors in sync.
+     * @param limits Array to store current limits for each motor.
+     * @return uint8_t 0 on success, nonzero on error.
+     */
+    template <uint8_t N>
+    uint8_t getCurrentLimit(uint16_t (&limits)[N]);
+
+    /**     * @brief Sets the actuator’s desired output position (pulses) for Position Control Mode.
      * @param goalPosition Desired position (0 to 4095 pulses).
      * @return uint8_t 0 on success.
      */

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
@@ -195,6 +195,29 @@ uint8_t DynamixelLL::setHomingOffset_A(const float (&offsetAngle)[N])
 
 
 template <uint8_t N>
+uint8_t DynamixelLL::setCurrentLimit(const uint16_t (&limits)[N])
+{
+    if (checkArraySize(N) != 0)
+        return 1;
+
+    uint32_t processedLimits[_numMotors];
+    for (uint8_t i = 0; i < _numMotors; i++)
+        processedLimits[i] = (limits[i] > 2047) ? 2047 : limits[i];
+
+    return syncWrite(38, 2, _motorIDs, processedLimits, _numMotors);
+}
+
+
+template <uint8_t N>
+uint8_t DynamixelLL::getCurrentLimit(uint16_t (&limits)[N])
+{
+    if (checkArraySize(N) != 0)
+        return 1;
+    return syncRead(38, 2, _motorIDs, limits, _numMotors);
+}
+
+
+template <uint8_t N>
 uint8_t DynamixelLL::setGoalPosition_PCM(const uint16_t (&goalPositions)[N])
 {
     if (checkArraySize(N) != 0)


### PR DESCRIPTION
## Summary

Adds software current limiting for XM540-W270 motors to protect mechanical components from excessive torque. Sets current limit to 1200 units (≈ 3.2A) via EEPROM register 38 during arm initialization.

Closes #30

## Changes

- **`setCurrentLimit()` / `getCurrentLimit()`**: New methods in `Dynamixel_ll` for single motor and sync group (template)
- **`ARM_XM540_CURRENT_LIMIT`**: Defined as 1200 in `definitions.h` (2.69mA/unit × 1200 = 3.228A, vs max 4.1A)
- **Applied in `MODC_ARM_INIT()`**: Sets current limit for XM540 motors (IDs 210, 211, 112) before enabling torque

## After Merge — Documentation Tasks

- [ ] Update [Motor Configuration](https://docs.teamisaac.it) docs: document XM540 current limit setting and rationale
- [ ] Consider adding current limit values to the motor parameters table

## Validation

- [x] Built MOD1 — passes
- [ ] Hardware test: verify current limit is written to EEPROM (read back via `getCurrentLimit()`)
- [ ] Hardware test: verify motors still have adequate torque for normal operation
- [ ] Stress test: verify motors shut down gracefully at current limit