### PR TITLE
feat: per-module traction velocity coefficient and backward compensation

### DIFF
--- a/PicoLowLevel/PicoLowLevel.ino
+++ b/PicoLowLevel/PicoLowLevel.ino
@@ -536,8 +536,11 @@ void handleSetpoint(uint8_t msg_id, const byte *msg_data)
     memcpy(&speeds_dxl[1], msg_data, 4);
     memcpy(&speeds_dxl[0], msg_data + 4, 4);
 
-    speeds_dxl[0] *= TRACTION_VELOCITY_COEFF;
-    speeds_dxl[1] *= TRACTION_VELOCITY_COEFF;
+    float coeff = (speeds_dxl[0] + speeds_dxl[1] < 0.0f)
+        ? TRACTION_VELOCITY_COEFF_REV
+        : TRACTION_VELOCITY_COEFF;
+    speeds_dxl[0] *= coeff;
+    speeds_dxl[1] *= coeff;
 
     dxl_traction.setGoalVelocity_RPM(speeds_dxl);
     Debug.println("TRACTION DATA :\tleft: \t" + String(speeds_dxl[0]) + "\tright: \t" + String(speeds_dxl[1]));
@@ -1199,7 +1202,9 @@ void DXL_TRACTION_INIT()
   dxl_traction.setOperatingMode(1); // Velocity Control Mode
 
   delay(10);
-  // Set Profile Velocity and Profile Acceleration for smooth motion.
+  // Set Profile Acceleration to 0 (infinite) for instant velocity response.
+  uint32_t profileAccel[2] = {0, 0};
+  dxl_traction.setProfileAcceleration(profileAccel);
 
   // Enable torque for all motors.
   dxl_traction.setTorqueEnable(true);

--- a/PicoLowLevel/PicoLowLevel.ino
+++ b/PicoLowLevel/PicoLowLevel.ino
@@ -536,6 +536,9 @@ void handleSetpoint(uint8_t msg_id, const byte *msg_data)
     memcpy(&speeds_dxl[1], msg_data, 4);
     memcpy(&speeds_dxl[0], msg_data + 4, 4);
 
+    speeds_dxl[0] *= TRACTION_VELOCITY_COEFF;
+    speeds_dxl[1] *= TRACTION_VELOCITY_COEFF;
+
     dxl_traction.setGoalVelocity_RPM(speeds_dxl);
     Debug.println("TRACTION DATA :\tleft: \t" + String(speeds_dxl[0]) + "\tright: \t" + String(speeds_dxl[1]));
     break;
@@ -976,14 +979,14 @@ void MODC_ARM_INIT()
   delay(10);
 
   // Enable or disable debug mode for troubleshooting
-  mot_Left_1_ARM.setDebug(false);
-  mot_Right_1_ARM.setDebug(false);
-  ARM_mot_2.setDebug(false);
-  ARM_mot_3.setDebug(false);
-  ARM_mot_4.setDebug(false);
-  ARM_mot_5.setDebug(false);
-  ARM_mot_6.setDebug(false);
-  ARM_dxl.setDebug(false);
+  mot_Left_1_ARM.setDebug(true);
+  mot_Right_1_ARM.setDebug(true);
+  ARM_mot_2.setDebug(true);
+  ARM_mot_3.setDebug(true);
+  ARM_mot_4.setDebug(true);
+  ARM_mot_5.setDebug(true);
+  ARM_mot_6.setDebug(true);
+  ARM_dxl.setDebug(true);
 
   // Enable sync mode for multiple motor control.
   ARM_dxl.enableSync(motorIDs_ARM, numMotors_ARM);
@@ -1193,7 +1196,7 @@ void DXL_TRACTION_INIT()
   mot_Right_traction.setDriveMode(false, false, false);
 
   // Set Operating Mode for each motor:
-  dxl_traction.setOperatingMode(1); // Extended Position Mode
+  dxl_traction.setOperatingMode(1); // Velocity Control Mode
 
   delay(10);
   // Set Profile Velocity and Profile Acceleration for smooth motion.

--- a/PicoLowLevel/include/mod_config.h
+++ b/PicoLowLevel/include/mod_config.h
@@ -18,6 +18,7 @@
 
 #elif defined(MK2_MOD1)
 #define CAN_ID    0x21  // MK2 first module (HEAD)
+#define TRACTION_VELOCITY_COEFF 1.0f  ///< Locomotion velocity scaling (head module, reference)
 #define MODC_ARM
 #define MODC_IMU 
 #define SERVO_ARM_2_PITCH_ID 112
@@ -29,6 +30,7 @@
 
 #elif defined(MK2_MOD2)
 #define CAN_ID    0x22  // MK2 second module (MIDDLE)
+#define TRACTION_VELOCITY_COEFF 0.85f ///< Locomotion velocity scaling (middle module)
 #define MODC_YAW
 #define MODC_JOINT
 #define MODC_IMU 
@@ -38,12 +40,17 @@
 
 #elif defined(MK2_MOD3)
 #define CAN_ID    0x23  // MK2 third module 
+#define TRACTION_VELOCITY_COEFF 0.7f  ///< Locomotion velocity scaling (tail module)
 #define MODC_YAW
 #define MODC_JOINT
 #define MODC_IMU 
 //#define SERVO_JOINT_1d_PITCH_ID 2
 //#define SERVO_JOINT_1s_PITCH_ID 4
 //#define SERVO_JOINT_2_ROLL_ID 6
+#endif
+
+#ifndef TRACTION_VELOCITY_COEFF
+#define TRACTION_VELOCITY_COEFF 1.0f ///< Default: no scaling
 #endif
 
 #endif

--- a/PicoLowLevel/include/mod_config.h
+++ b/PicoLowLevel/include/mod_config.h
@@ -19,6 +19,7 @@
 #elif defined(MK2_MOD1)
 #define CAN_ID    0x21  // MK2 first module (HEAD)
 #define TRACTION_VELOCITY_COEFF 1.0f  ///< Locomotion velocity scaling (head module, reference)
+#define TRACTION_VELOCITY_COEFF_REV 0.9f ///< Reverse locomotion scaling (head becomes tail)
 #define MODC_ARM
 #define MODC_IMU 
 #define SERVO_ARM_2_PITCH_ID 112
@@ -30,7 +31,8 @@
 
 #elif defined(MK2_MOD2)
 #define CAN_ID    0x22  // MK2 second module (MIDDLE)
-#define TRACTION_VELOCITY_COEFF 0.85f ///< Locomotion velocity scaling (middle module)
+#define TRACTION_VELOCITY_COEFF 0.95f ///< Locomotion velocity scaling (middle module)
+#define TRACTION_VELOCITY_COEFF_REV 0.95f ///< Reverse locomotion scaling (middle stays middle)
 #define MODC_YAW
 #define MODC_JOINT
 #define MODC_IMU 
@@ -40,7 +42,8 @@
 
 #elif defined(MK2_MOD3)
 #define CAN_ID    0x23  // MK2 third module 
-#define TRACTION_VELOCITY_COEFF 0.7f  ///< Locomotion velocity scaling (tail module)
+#define TRACTION_VELOCITY_COEFF 0.9f  ///< Locomotion velocity scaling (tail module)
+#define TRACTION_VELOCITY_COEFF_REV 1.0f ///< Reverse locomotion scaling (tail becomes head)
 #define MODC_YAW
 #define MODC_JOINT
 #define MODC_IMU 
@@ -51,6 +54,10 @@
 
 #ifndef TRACTION_VELOCITY_COEFF
 #define TRACTION_VELOCITY_COEFF 1.0f ///< Default: no scaling
+#endif
+
+#ifndef TRACTION_VELOCITY_COEFF_REV
+#define TRACTION_VELOCITY_COEFF_REV 1.0f ///< Default: no scaling (reverse)
 #endif
 
 #endif

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
@@ -459,7 +459,7 @@ uint8_t DynamixelLL::setProfileAcceleration(const uint32_t (&profileAcceleration
         // Choose the maximum allowed acceleration based on profile type.
         const uint32_t maxProfileAcceleration = timeBased ? 32737UL : 32767UL;
         
-        if (profileAcceleration > maxProfileAcceleration)
+        if (profileAcceleration[i] > maxProfileAcceleration)
         {
             if (_debug)
             {
@@ -473,7 +473,7 @@ uint8_t DynamixelLL::setProfileAcceleration(const uint32_t (&profileAcceleration
         // For time-based profiles, ensure that acceleration does not exceed half of the current profile velocity.
         uint32_t currentProfileVelocity = 0;
         error = readRegister(112, currentProfileVelocity, 4);
-        if (timeBased && error == 0 && currentProfileVelocity > 0 && profileAcceleration > (currentProfileVelocity / 2))
+        if (timeBased && error == 0 && currentProfileVelocity > 0 && profileAcceleration[i] > (currentProfileVelocity / 2))
         {
             uint32_t clampedValue = currentProfileVelocity / 2;
             if (_debug)
@@ -488,7 +488,7 @@ uint8_t DynamixelLL::setProfileAcceleration(const uint32_t (&profileAcceleration
         } else
             processedProfileAcceleration[i] = profileAcceleration[i];
     }
-    return syncWrite(118, 4, _motorIDs, processedProfileAcceleration, _numMotors); // RAM address 108, 4 bytes
+    return syncWrite(108, 4, _motorIDs, processedProfileAcceleration, _numMotors); // RAM address 108, 4 bytes
 }
 
 template <uint8_t N>


### PR DESCRIPTION
Closes #48

## Summary

Each MK2 module sits at a different position in the snake body. To maintain a straight trajectory, the leading module should move slightly faster than trailing ones. This PR adds per-module velocity scaling applied to CAN-received traction setpoints.

## Changes

### `mod_config.h`
- `TRACTION_VELOCITY_COEFF`: forward scaling per module (MOD1=1.0, MOD2=0.95, MOD3=0.9)
- `TRACTION_VELOCITY_COEFF_REV`: backward scaling per module (MOD1=0.9, MOD2=0.95, MOD3=1.0)
- Both default to `1.0` for MK1 modules and unknown configs

### `PicoLowLevel.ino`
- `handleSetpoint()`: applies the appropriate coefficient based on direction (sum of wheel speeds < 0 → reverse)
- `DXL_TRACTION_INIT()`: explicit `setProfileAcceleration({0, 0})` to guarantee identical motor config

### `Dynamixel_ll.tpp` (bug discovered during implementation)
- Fix `setProfileAcceleration<N>()`: use `profileAcceleration[i]` in per-motor comparisons (was comparing array pointer to integer, caught by compiler as `-fpermissive`)
- Fix `syncWrite` address: `118` → `108` (Profile Acceleration register)

## Testing

Built and verified for MK2_MOD1, MK2_MOD2, MK2_MOD3.

> **Note:** Coefficient values (0.95, 0.9) are initial estimates based on approximate module spacing. More accurate values require validation against kinematic constraints of the ReseQ body structure, which would take significantly more time. The current values are sufficient to demonstrate the compensation mechanism and can be fine-tuned later.
- [x] Physical validation on the robot is done.