### PR TITLE
feat: add current limit protection for XM540 motors and closes #

### DIFF
--- a/PicoLowLevel/PicoLowLevel.ino
+++ b/PicoLowLevel/PicoLowLevel.ino
@@ -1059,6 +1059,17 @@ void MODC_ARM_INIT()
 
   delay(10);
 
+  // Set Current Limit for Joint Motors
+  ARM_dxl.setCurrentLimit(ARM_CURRENT_LIMIT);
+  ARM_mot_2.setCurrentLimit(ARM_CURRENT_LIMIT);
+  // For these joints, no current limit registers are available.
+  // ARM_mot_3.setCurrentLimit(ARM_CURRENT_LIMIT);
+  // ARM_mot_4.setCurrentLimit(ARM_CURRENT_LIMIT);
+  // ARM_mot_5.setCurrentLimit(ARM_CURRENT_LIMIT);
+  // ARM_mot_6.setCurrentLimit(ARM_CURRENT_LIMIT);
+
+  delay(10);
+
   // NOW enable torque safely — motors stay in place since goal ≈ current
   ARM_dxl.setTorqueEnable(true);
   mot_Left_1_ARM.setTorqueEnable(true);
@@ -1152,6 +1163,13 @@ void MODC_JOINT_INIT()
   
 
   delay(10);
+
+  // Set Current Limit for each motor
+  JOINT_dxl.setCurrentLimit(JOINT_CURRENT_LIMIT);
+  JOINT_mot_Left_1.setCurrentLimit(JOINT_CURRENT_LIMIT);
+  JOINT_mot_Right_1.setCurrentLimit(JOINT_CURRENT_LIMIT);
+
+  delay(10);
   // Enable torque for all motors.
   JOINT_dxl.setTorqueEnable(true);
   JOINT_mot_Left_1.setTorqueEnable(true);
@@ -1205,6 +1223,10 @@ void DXL_TRACTION_INIT()
   // Set Profile Acceleration to 0 (infinite) for instant velocity response.
   uint32_t profileAccel[2] = {0, 0};
   dxl_traction.setProfileAcceleration(profileAccel);
+
+  // Set Current Limit for all motors.
+  uint16_t currentLimit[2] = {TRACTION_CURRENT_LIMIT, TRACTION_CURRENT_LIMIT};
+  dxl_traction.setCurrentLimit(currentLimit);
 
   // Enable torque for all motors.
   dxl_traction.setTorqueEnable(true);

--- a/PicoLowLevel/include/definitions.h
+++ b/PicoLowLevel/include/definitions.h
@@ -48,6 +48,11 @@
 // Motor configuration
 #define MAX_SPEED 65.f
 
+// MOTOR CURRENT LIMIT
+#define ARM_CURRENT_LIMIT 1100        //~ 3A
+#define JOINT_CURRENT_LIMIT 1100      //~ 3A
+#define TRACTION_CURRENT_LIMIT 1500   //~ 4A
+
 // Encoder pins
 #define ENC_TR_LEFT_A   12
 #define ENC_TR_LEFT_B   13

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.cpp
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.cpp
@@ -1252,3 +1252,41 @@ uint8_t DynamixelLL::getPresentTemperature(uint8_t &temperature)
     }
     return error;
 }
+
+uint8_t DynamixelLL::setCurrentLimit(uint16_t currentLimit)
+{
+    if (currentLimit > 2047)
+    {
+        if (_debug) Serial.println("Error: Current limit exceeds maximum (2047).");
+        return 1;
+    }
+
+    uint8_t torqueState;
+    uint8_t err = readRegister(64, torqueState, 1); // RAM address 64, 1 byte
+    if (err != 0) return err;
+
+    // It should not be possible to set the current limit while torque is enabled.
+    // If toqrue is enabled, the EEPROM is locked and the current limit cannot be written.
+    // As a safety measure, check that torque is disabled before setting the current limit.
+    if (torqueState)
+    {
+        if (_debug) Serial.println("Error: Disable torque before setting current limit.");
+        return 1;
+    }
+
+    return writeRegister(38, static_cast<uint32_t>(currentLimit), 2); // EEPROM address 38, 2 bytes
+} 
+
+uint8_t DynamixelLL::getCurrentLimit(uint16_t &currentLimit)
+{
+    uint8_t error = readRegister(38, currentLimit, 2); // EEPROM address 38, 2 byte
+    if (error != 0)
+    {
+        if (_debug)
+        {
+            Serial.print("Error reading Current Limit: ");
+            Serial.println(error, HEX);
+        }
+    }
+    return error;
+}

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.h
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.h
@@ -524,6 +524,24 @@ public:
      */
     uint8_t reboot();
 
+    // Current Limit Management --> Added by Aminadab Z.
+    // ---------------------------------------------------------------------------
+    /** 
+     * @brief A function to set the current limit for a single motor.
+     * @param limit The current limit to set.
+     * @return uint8_t 0 if successful, nonzero if failed.
+    */
+    uint8_t setCurrentLimit(uint16_t limit);   // single motor
+    template <uint8_t N>
+    uint8_t setCurrentLimit(const uint16_t (&limits)[N]);
+
+    /** 
+     * @brief A function to obtain the current limit for a single motor from the register.
+     * @param limit Reference to store the current limit.
+     * @return uint8_t 0 if successful, nonzero if failed.
+    */
+    uint8_t getCurrentLimit(uint16_t &limit);  // single motor
+
 private:
     HardwareSerial &_serial; ///< Reference to the serial interface.
     uint8_t _servoID;        ///< Servo ID.
@@ -667,6 +685,10 @@ private:
      * @return uint8_t 0 if valid, nonzero if invalid.
      */
     uint8_t checkArraySize(uint8_t arraySize) const;
+
+    
+
+
 };
 
 // Include the template definitions.

--- a/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
+++ b/PicoLowLevel/lib/Dynamixel_ll/src/Dynamixel_ll.tpp
@@ -628,3 +628,34 @@ uint8_t DynamixelLL::getPresentVelocity_RPM(float (&rpms)[N])
     }
     return error;
 }
+
+template <uint8_t N>
+uint8_t DynamixelLL::setCurrentLimit(const uint16_t (&limits)[N])
+{
+    if (checkArraySize(N) != 0)
+        return 1;
+
+    // Check torque is disabled before writing EEPROM
+    uint8_t torqueState;
+    uint8_t err = readRegister(64, torqueState, 1);
+    if (err != 0) return err;
+    if (torqueState)
+    {
+        if (_debug) Serial.println("Error: Disable torque before setting current limit.");
+        return 1;
+    }
+
+    // Validate and convert each limit to uint32_t for syncWrite
+    uint32_t processedLimits[_numMotors];
+    for (uint8_t i = 0; i < _numMotors; i++)
+    {
+        if (limits[i] > 2047)
+        {
+            if (_debug) Serial.println("Error: Current limit exceeds maximum (2047).");
+            return 1;
+        }
+        processedLimits[i] = static_cast<uint32_t>(limits[i]);
+    }
+
+    return syncWrite(38, 2, _motorIDs, processedLimits, _numMotors); // EEPROM address 38, 2 bytes
+}


### PR DESCRIPTION
- Add setCurrentLimit() and getCurrentLimit() for single motor

- Add setCurrentLimit() sync template in .tpp for multiple motors

- Guard against writing EEPROM while torque is enabled

- Set limits during init before torque enable in PicoLowLevel.ino

- Skip XL430 motors (no current limit register)

- Closes #30 